### PR TITLE
[fix] 'combined' is not in View Layer

### DIFF
--- a/skinning/functions.py
+++ b/skinning/functions.py
@@ -34,11 +34,9 @@ def generate_combined_skinning_mesh(armature: Object):
     if not combined_mesh.visible_get(view_layer=bpy.context.view_layer):
         scene_collection = bpy.context.scene.collection
         scene_collection.objects.link(combined_mesh)
-        combined_mesh.select_set(True)
-        bpy.ops.object.parent_set(type="ARMATURE_NAME")
-    else:
-        combined_mesh.select_set(True)
-        bpy.ops.object.parent_set(type="ARMATURE_NAME")
+
+    combined_mesh.select_set(True)
+    bpy.ops.object.parent_set(type="ARMATURE_NAME")
 
     mech_mesh_collection = get_or_create_collection("Combined Skinning Mesh")
     link_to_collection(mech_mesh_collection, armature)

--- a/skinning/functions.py
+++ b/skinning/functions.py
@@ -28,8 +28,17 @@ def generate_combined_skinning_mesh(armature: Object):
     combined_mesh = generate_mesh_object("combined", [], [], [])
     deselect_all()
     set_active_object(armature)
-    combined_mesh.select_set(True)
-    bpy.ops.object.parent_set(type="ARMATURE_NAME")
+    # context.scene.collection.children[0]にリンクしているが、それがview layerから除外されていると
+    # RuntimeError: Error: Object 'combined' can't be selected because it is not in View Layer 'View Layer'!
+    # になるのでその時はscene collection直下にもリンクする
+    if not combined_mesh.visible_get(view_layer=bpy.context.view_layer):
+        scene_collection = bpy.context.scene.collection
+        scene_collection.objects.link(combined_mesh)
+        combined_mesh.select_set(True)
+        bpy.ops.object.parent_set(type="ARMATURE_NAME")
+    else:
+        combined_mesh.select_set(True)
+        bpy.ops.object.parent_set(type="ARMATURE_NAME")
 
     mech_mesh_collection = get_or_create_collection("Combined Skinning Mesh")
     link_to_collection(mech_mesh_collection, armature)


### PR DESCRIPTION
"combined"オブジェクト生成時にcontext.scene.collection.children[0]にリンクしているが、それがview layerから除外されていると
RuntimeError: Error: Object 'combined' can't be selected because it is not in View Layer 'View Layer'!
になるのでその時はscene collection直下にもリンクする